### PR TITLE
fix: propagate upstream errors to client instead of empty responses

### DIFF
--- a/src/proxy.py
+++ b/src/proxy.py
@@ -1910,6 +1910,23 @@ def extract_text_delta(event: Optional[str], data: str) -> Tuple[str, Optional[D
 
     if event_type in ("error", "response.failed") or obj.get("error"):
         return "error", obj
+    # WHY: vLLM upstreams return errors in various non-standard formats when
+    # context overflows or other issues occur during streaming. The error may
+    # appear as: {"object": "error", "message": "..."}, or the SSE event type
+    # may be "error" while the JSON "type" field is different. Detect these
+    # so upstream errors are propagated to the client instead of being silently
+    # ignored (which results in empty responses).
+    if isinstance(obj, dict):
+        # vLLM format: {"object": "error", "message": "...", "type": "..."}
+        if obj.get("object") == "error" and obj.get("message"):
+            return "error", obj
+        # Some vLLM versions: {"detail": "error message", "type": "..."}
+        if obj.get("detail") and isinstance(obj.get("detail"), str) and not obj.get("choices"):
+            return "error", {"error": {"type": "upstream_error", "message": obj["detail"]}, "raw": obj}
+        # Chat completions error: {"error": {"message": "...", "type": "..."}}
+        err = obj.get("error")
+        if isinstance(err, dict) and err.get("message"):
+            return "error", obj
     return "ignore", obj
 
 def parse_tool_arguments(arguments: Any) -> Dict[str, Any]:
@@ -3232,6 +3249,21 @@ class ProxyHandler(BaseHTTPRequestHandler):
             for pseudo_tool_call in pseudo_tool_calls:
                 merge_tool_call_payloads(tool_calls, pseudo_tool_call)
         if not output_text and not tool_calls:
+            # WHY: Check for upstream error in done_payload and retry response
+            # before falling back to a generic error message.
+            codex_upstream_error = ""
+            if isinstance(done_payload, dict):
+                raw_obj = done_payload.get("raw", done_payload)
+                if isinstance(raw_obj, dict):
+                    err = raw_obj.get("error")
+                    if isinstance(err, dict) and err.get("message"):
+                        codex_upstream_error = err["message"]
+                    elif isinstance(err, str) and err:
+                        codex_upstream_error = err
+                    elif raw_obj.get("object") == "error" and raw_obj.get("message"):
+                        codex_upstream_error = raw_obj["message"]
+                    elif raw_obj.get("detail") and isinstance(raw_obj.get("detail"), str):
+                        codex_upstream_error = raw_obj["detail"]
             retry_payload = dict(upstream_payload)
             retry_payload["stream"] = False
             retry_payload.pop("stream_options", None)
@@ -3239,6 +3271,18 @@ class ProxyHandler(BaseHTTPRequestHandler):
                 with open_upstream(retry_payload, auth_token, upstream_url, timeout, model_config.api_format) as response:
                     raw_payload = response.read().decode("utf-8", errors="replace")
                 fallback_payload = json.loads(raw_payload)
+                # WHY: Check if non-stream retry returned an error response
+                if isinstance(fallback_payload, dict):
+                    err = fallback_payload.get("error")
+                    if isinstance(err, dict) and err.get("message"):
+                        codex_upstream_error = codex_upstream_error or err["message"]
+                        log(f"codex stream retry returned error model={model_config.model_id} error={err['message'][:200]}")
+                    elif fallback_payload.get("object") == "error" and fallback_payload.get("message"):
+                        codex_upstream_error = codex_upstream_error or fallback_payload["message"]
+                        log(f"codex stream retry returned error model={model_config.model_id} error={fallback_payload['message'][:200]}")
+                    elif fallback_payload.get("detail") and isinstance(fallback_payload.get("detail"), str):
+                        codex_upstream_error = codex_upstream_error or fallback_payload["detail"]
+                        log(f"codex stream retry returned error model={model_config.model_id} detail={fallback_payload['detail'][:200]}")
                 log(f"codex empty stream fallback model={model_config.model_id}")
                 output_text = response_text_from_upstream_json(fallback_payload)
                 if not output_text and isinstance(fallback_payload.get("choices"), list):
@@ -3250,10 +3294,16 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     )
                     output_text = responses_json_output_text(converted.get("output", []))
                 log(f"codex empty stream fallback model={model_config.model_id} chars={len(output_text)}")
+            except urllib.error.HTTPError as retry_http_exc:
+                retry_body = retry_http_exc.read().decode("utf-8", errors="replace")
+                retry_msg = f"HTTP {retry_http_exc.code}: {retry_body[:300]}"
+                codex_upstream_error = codex_upstream_error or retry_msg
+                log(f"codex stream retry http error model={model_config.model_id} {retry_msg}")
             except Exception as exc:
                 log(f"codex empty stream fallback failed model={model_config.model_id} error={exc}")
         if not output_text and not tool_calls:
-            emit("response.failed", {"response": {"id": request_id, "status": "failed", "error": {"type": "api_error", "message": "Upstream completed without assistant text or tool calls"}}})
+            error_msg = codex_upstream_error or "Upstream completed without assistant text or tool calls"
+            emit("response.failed", {"response": {"id": request_id, "status": "failed", "error": {"type": "api_error", "message": error_msg}}})
             write_data_sse(self, "[DONE]")
             self.close_connection = True
             return
@@ -3532,6 +3582,9 @@ class ProxyHandler(BaseHTTPRequestHandler):
         done_payload: Optional[Dict[str, Any]] = None
         chat_stream_usage: Optional[Dict[str, Any]] = None
         thinking_state: Dict[str, Any] = {"in_thinking": False}
+        # WHY: Collect upstream error info from SSE events so it can be
+        # propagated to the client instead of producing an empty response.
+        stream_error_message: str = ""
         stream_bridge = model_config.stream_bridge
         if model_config.api_format == "chat_completions" and stream_bridge:
             non_stream_payload = dict(upstream_payload)
@@ -3748,7 +3801,26 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     elif kind == "usage" and parsed and isinstance(parsed.get("usage"), dict):
                         chat_stream_usage = parsed["usage"]
                     elif kind == "error":
-                        self._send_anthropic_stream_error(json.dumps(parsed, ensure_ascii=False), text_block_started, text_block_stopped)
+                        # WHY: Extract a human-readable error message from the upstream
+                        # error payload before sending to client. This message is also
+                        # saved in stream_error_message as a safety net in case the
+                        # SSE write fails and we fall through to the empty-stream path.
+                        _err_msg = ""
+                        if isinstance(parsed, dict):
+                            err_obj = parsed.get("error")
+                            if isinstance(err_obj, dict):
+                                _err_msg = err_obj.get("message", "")
+                            elif isinstance(err_obj, str):
+                                _err_msg = err_obj
+                            if not _err_msg and parsed.get("message"):
+                                _err_msg = parsed["message"]
+                            if not _err_msg and parsed.get("detail"):
+                                _err_msg = str(parsed["detail"])
+                        if not _err_msg:
+                            _err_msg = json.dumps(parsed, ensure_ascii=False)[:500]
+                        stream_error_message = _err_msg
+                        log(f"upstream stream error model={model_config.model_id} error={_err_msg[:200]}")
+                        self._send_anthropic_stream_error(_err_msg, text_block_started, text_block_stopped)
                         return
                     elif kind == "done":
                         done_payload = parsed
@@ -3806,6 +3878,26 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     fallback_choices = done_payload.get("raw", {}).get("choices") if isinstance(done_payload.get("raw"), dict) else None
                     if isinstance(fallback_choices, list) and fallback_choices:
                         output_text = fallback_choices[0].get("message", {}).get("content", "") if isinstance(fallback_choices[0], dict) else ""
+            # WHY: Check if the ignored SSE events contained an upstream error.
+            # When upstream returns HTTP 200 but the SSE body contains an error
+            # (e.g. vLLM context overflow), extract_text_delta() may have
+            # returned "error" before the fix, but some edge-case formats
+            # might still be missed. Check done_payload and stream_error_message
+            # as safety nets.
+            upstream_error_message_text = stream_error_message
+            if isinstance(done_payload, dict):
+                # Check done_payload for error info (chat completions format)
+                raw_obj = done_payload.get("raw", done_payload)
+                if isinstance(raw_obj, dict):
+                    err = raw_obj.get("error")
+                    if isinstance(err, dict) and err.get("message"):
+                        upstream_error_message_text = err["message"]
+                    elif isinstance(err, str) and err:
+                        upstream_error_message_text = err
+                    elif raw_obj.get("object") == "error" and raw_obj.get("message"):
+                        upstream_error_message_text = raw_obj["message"]
+                    elif raw_obj.get("detail") and isinstance(raw_obj.get("detail"), str):
+                        upstream_error_message_text = raw_obj["detail"]
             # Step 2: If done_payload extraction failed, re-issue as non-streaming
             if not output_text:
                 retry_payload = dict(upstream_payload)
@@ -3815,6 +3907,20 @@ class ProxyHandler(BaseHTTPRequestHandler):
                     with open_upstream(retry_payload, auth_token, upstream_url, timeout, model_config.api_format) as retry_resp:
                         raw_retry = retry_resp.read().decode("utf-8", errors="replace")
                     retry_json = json.loads(raw_retry)
+                    # WHY: Check if non-stream retry returned an error response
+                    # (e.g. context overflow). If so, extract the error message
+                    # instead of silently producing an empty response.
+                    if isinstance(retry_json, dict):
+                        err = retry_json.get("error")
+                        if isinstance(err, dict) and err.get("message"):
+                            upstream_error_message_text = upstream_error_message_text or err["message"]
+                            log(f"anthropic stream retry returned error model={model_config.model_id} error={err['message'][:200]}")
+                        elif retry_json.get("object") == "error" and retry_json.get("message"):
+                            upstream_error_message_text = upstream_error_message_text or retry_json["message"]
+                            log(f"anthropic stream retry returned error model={model_config.model_id} error={retry_json['message'][:200]}")
+                        elif retry_json.get("detail") and isinstance(retry_json.get("detail"), str):
+                            upstream_error_message_text = upstream_error_message_text or retry_json["detail"]
+                            log(f"anthropic stream retry returned error model={model_config.model_id} detail={retry_json['detail'][:200]}")
                     output_text = response_text_from_upstream_json(retry_json)
                     if not output_text and model_config.api_format == "chat_completions" and isinstance(retry_json.get("choices"), list):
                         converted = chat_completion_json_to_responses(
@@ -3823,8 +3929,21 @@ class ProxyHandler(BaseHTTPRequestHandler):
                             retry_payload.get("tools") if isinstance(retry_payload.get("tools"), list) else None,
                         )
                         output_text = responses_json_output_text(converted.get("output", []))
+                except urllib.error.HTTPError as retry_http_exc:
+                    retry_body = retry_http_exc.read().decode("utf-8", errors="replace")
+                    retry_msg = f"HTTP {retry_http_exc.code}: {retry_body[:300]}"
+                    upstream_error_message_text = upstream_error_message_text or retry_msg
+                    log(f"anthropic stream retry http error model={model_config.model_id} {retry_msg}")
                 except Exception as retry_exc:
                     log(f"anthropic stream non-stream retry failed model={model_config.model_id} error={retry_exc}")
+            # WHY: If both stream and retry failed and we have an upstream error
+            # message, send it to the client instead of an empty response.
+            # This ensures the user sees the actual error (e.g. context overflow)
+            # instead of a silent empty reply.
+            if not output_text and not tool_calls and upstream_error_message_text:
+                log(f"anthropic empty stream with upstream error model={model_config.model_id} error={upstream_error_message_text[:200]}")
+                self._send_anthropic_stream_error(upstream_error_message_text, text_block_started, text_block_stopped)
+                return
             log(f"anthropic empty stream fallback model={model_config.model_id} chars={len(output_text)}")
             if output_text and not text_block_started:
                 # Fallback recovered text - emit content_block events

--- a/tests/test_upstream_error.py
+++ b/tests/test_upstream_error.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Test: Verify that upstream errors (e.g. context overflow) are properly
+propagated to the downstream client instead of resulting in empty responses.
+
+Usage:
+  python tests/test_upstream_error.py [--proxy-url URL] [--api-key KEY]
+  python tests/test_upstream_error.py --direct-only --upstream-api-key KEY
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+DEFAULT_PROXY_URL = "http://127.0.0.1:8091"
+DEFAULT_API_KEY = "local-proxy"
+
+
+def test_context_overflow_raw(proxy_url: str, api_key: str) -> None:
+    """Send a request that will cause context overflow and inspect the raw SSE response."""
+    large_text = "This is a test sentence. " * 20000  # ~800K chars ≈ 200K tokens
+
+    payload = {
+        "model": "deepseek-pro",
+        "max_tokens": 16384,
+        "stream": True,
+        "messages": [
+            {"role": "user", "content": large_text}
+        ],
+    }
+
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {
+        "content-type": "application/json",
+        "accept": "text/event-stream",
+        "authorization": f"Bearer {api_key}",
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+
+    url = f"{proxy_url}/v1/messages"
+    print(f"[TEST] Sending large context overflow request to {url}")
+    print(f"[TEST] Payload size: {len(data) // 1024} KB")
+
+    try:
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        response = urllib.request.urlopen(req, timeout=120)
+        status = response.status
+        print(f"[TEST] Response status: {status}")
+
+        print(f"[TEST] Raw SSE events:")
+        print("-" * 60)
+        event_count = 0
+        has_error = False
+        has_text_content = False
+        error_content = None
+
+        while True:
+            raw = response.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                continue
+
+            if line.startswith("event:"):
+                event_type = line[6:].strip()
+                print(f"  event: {event_type}")
+            elif line.startswith("data:"):
+                data_str = line[5:].strip()
+                try:
+                    parsed = json.loads(data_str)
+                    event_type = parsed.get("type", "")
+                    if event_type in ("error",) or parsed.get("error"):
+                        has_error = True
+                        error_content = parsed
+                        print(f"  ⚠️  ERROR EVENT: {json.dumps(parsed, ensure_ascii=False)[:500]}")
+                    elif event_type == "content_block_delta":
+                        delta = parsed.get("delta", {})
+                        text = delta.get("text", "")
+                        if text:
+                            has_text_content = True
+                            if "[Proxy Error]" in text:
+                                has_error = True
+                                error_content = parsed
+                            print(f"  📝 text delta: {text[:100]}{'...' if len(text) > 100 else ''}")
+                        thinking = delta.get("thinking", "")
+                        if thinking:
+                            print(f"  🧠 thinking delta: {thinking[:80]}...")
+                    elif event_type == "message_stop":
+                        print(f"  ✅ message_stop")
+                    else:
+                        summary = json.dumps(parsed, ensure_ascii=False)
+                        if len(summary) > 200:
+                            summary = summary[:200] + "..."
+                        print(f"  📦 {event_type or 'unknown'}: {summary}")
+                except json.JSONDecodeError:
+                    if data_str == "[DONE]":
+                        print(f"  🔚 [DONE]")
+                    else:
+                        print(f"  ❓ raw data: {data_str[:200]}")
+                event_count += 1
+
+        print("-" * 60)
+        print(f"[TEST] Total events: {event_count}")
+        print(f"[TEST] Has error: {has_error}")
+        print(f"[TEST] Has text content: {has_text_content}")
+
+        if not has_error and not has_text_content:
+            print()
+            print("❌ BUG: Upstream error was NOT propagated to client!")
+        elif has_error:
+            print()
+            print("✅ Error was properly propagated to client.")
+        else:
+            print()
+            print("⚠️  Unexpected: got text content despite context overflow.")
+
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        print(f"[TEST] HTTP Error: {exc.code}")
+        print(f"[TEST] Body: {body[:500]}")
+        print()
+        print("✅ Upstream returned HTTP error (caught by urllib).")
+    except Exception as exc:
+        print(f"[TEST] Exception: {type(exc).__name__}: {exc}")
+
+
+def test_context_overflow_direct(upstream_url: str, upstream_model: str, api_key: str) -> None:
+    """Send directly to upstream to see the raw error format."""
+    large_text = "This is a test sentence. " * 20000
+
+    payload = {
+        "model": upstream_model,
+        "max_tokens": 16384,
+        "stream": True,
+        "messages": [
+            {"role": "user", "content": large_text}
+        ],
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
+
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {
+        "content-type": "application/json",
+        "accept": "text/event-stream",
+        "authorization": f"Bearer {api_key}",
+    }
+
+    print(f"\n[TEST-DIRECT] Sending directly to upstream: {upstream_url}")
+    print(f"[TEST-DIRECT] Payload size: {len(data) // 1024} KB")
+
+    try:
+        req = urllib.request.Request(upstream_url, data=data, headers=headers, method="POST")
+        response = urllib.request.urlopen(req, timeout=120)
+        print(f"[TEST-DIRECT] Response status: {response.status}")
+        print(f"[TEST-DIRECT] Raw upstream SSE:")
+        print("-" * 60)
+        line_count = 0
+        while line_count < 20:
+            raw = response.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+            if line:
+                print(f"  {line[:300]}")
+                line_count += 1
+        while True:
+            raw = response.readline()
+            if not raw:
+                break
+        print("-" * 60)
+
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        print(f"[TEST-DIRECT] HTTP Error: {exc.code}")
+        print(f"[TEST-DIRECT] Body: {body[:1000]}")
+        print()
+        print("📋 This is the raw error format the upstream returns.")
+    except Exception as exc:
+        print(f"[TEST-DIRECT] Exception: {type(exc).__name__}: {exc}")
+
+
+def main() -> None:
+    import argparse
+    parser = argparse.ArgumentParser(description="Test upstream error propagation")
+    parser.add_argument("--proxy-url", default=DEFAULT_PROXY_URL)
+    parser.add_argument("--upstream-url", default="https://genaiapi.shanghaitech.edu.cn/api/v1/start/chat/completions")
+    parser.add_argument("--upstream-model", default="deepseek-pro")
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY)
+    parser.add_argument("--upstream-api-key", default="")
+    parser.add_argument("--direct-only", action="store_true", help="Only test direct upstream")
+    args = parser.parse_args()
+
+    if not args.direct_only:
+        print("=" * 60)
+        print("TEST 1: Via proxy (check if error is propagated)")
+        print("=" * 60)
+        test_context_overflow_raw(args.proxy_url, args.api_key)
+
+    if args.upstream_api_key:
+        print()
+        print("=" * 60)
+        print("TEST 2: Direct upstream (see raw error format)")
+        print("=" * 60)
+        test_context_overflow_direct(args.upstream_url, args.upstream_model, args.upstream_api_key)
+    elif args.direct_only:
+        print("\n⚠️  --upstream-api-key required for direct upstream test")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

When upstream vLLM returns an error (e.g. context overflow) during streaming, it sends **HTTP 200** with error content in SSE data instead of an HTTP error code. The proxy's `extract_text_delta()` previously only detected standard error formats (`type="error"`, `response.failed`, `obj.error`), causing vLLM-specific error formats to be silently ignored as `"ignore"` events. This resulted in **empty responses** being sent to the downstream client.

### Before (broken)
```
upstream connected model=deepseek-pro format=chat_completions status=200
anthropic empty stream fallback model=deepseek-pro chars=0
response done model=deepseek-pro deltas=0 chars=0 tools=0
```
Client receives: empty message with `stop_reason: "end_turn"` — no error indication.

### After (fixed)
Client receives: `[Proxy Error] This model's maximum context length is 128000 tokens...` — the actual upstream error message.

## Changes

### 1. `extract_text_delta()` — detect vLLM error formats
Added detection for:
- `{"object": "error", "message": "..."}` (vLLM format)
- `{"detail": "error message"}` (some vLLM versions)
- `{"error": {"message": "..."}}` (chat completions error)

These previously fell through to `"ignore"` and were silently discarded.

### 2. `handle_streaming()` — propagate errors in Anthropic Messages path
- Added `stream_error_message` variable to collect error info from SSE events
- Error events now extract human-readable message instead of raw JSON dump
- Empty stream fallback extracts upstream error from `done_payload` and non-stream retry responses
- Calls `_send_anthropic_stream_error()` with actual error message instead of producing empty response

### 3. `handle_responses_streaming()` — propagate errors in Codex Responses path
- Same error extraction from `done_payload` and retry responses
- Uses actual upstream error in `response.failed` event instead of generic `"Upstream completed without assistant text or tool calls"`

### 4. Test script
Added `tests/test_upstream_error.py` for verifying error propagation.

## Testing
```bash
python tests/test_upstream_error.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)